### PR TITLE
Fix blog post timestamp date schema

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ script_path: '/dist/scripts/blog-post.js'
 		<h2>{{ page.title }}</h2>
 		<time
 			is="blog-post-timestamp"
-			datetime="{{ page.date }}"
+			datetime="{{ page.date | date_to_xmlschema }}"
 			class="label"
 			>{{ page.date | date: '%B %-d, %Y' }}</time
 		>

--- a/blog/index.html
+++ b/blog/index.html
@@ -11,7 +11,7 @@ title: Blog
 		{% if post.date %}
 		<time
 			is="blog-post-timestamp"
-			datetime="{{ post.date }}"
+			datetime="{{ post.date | date_to_xmlschema }}"
 			class="label"
 			>{{ post.date | date: '%B %-d, %Y' }}</time
 		>


### PR DESCRIPTION
The `BlogPostTimestamp` Web component attempts to convert its host `time` element's `timestamp` from ISO-8601 to a format it can manipulate to create a relative time string. But Jekyll wasn't correctly formatting the input `datetime` attribute in ISO-8601, causing `Date.parse` to return `NaN`, which produces the following error:

```
RangeError: date value is not finite in RelativeTimeFormat.format()
```

This PR corrects the server-side `datetime` formatting so it can be parsed as intended.